### PR TITLE
Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,9 @@
 name: Build and Push Docker Image
 
 on:
-  push:
-    branches: [docker-build]
-  workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          file: ./docker/Dockerfile
+          file: ./Docker/Dockerfile
           push: true
           tags: ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/splice2neo:${{ env.LATEST_RELEASE }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [docker-build]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Derive lowercase repo slug
+        run: echo "GITHUB_REPOSITORY_OWNER_LOWERCASE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      - name: Get latest release version
+        id: get_latest_release
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          echo "LATEST_RELEASE=$latest_release" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/splice2neo:${{ env.LATEST_RELEASE }}

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker/r-ver:4.2.3
+FROM rocker/r-ver:4.2.3
 
 ENV SRC /usr/local/src
 ENV BIN /usr/local/bin

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker://rocker/r-ver:4.2.3
+FROM docker/r-ver:4.2.3
 
 ENV SRC /usr/local/src
 ENV BIN /usr/local/bin


### PR DESCRIPTION
Hey, I prepared a new workflow for building the docker image. 

I tested it and it created the image https://github.com/TRON-Bioinformatics/splice2neo/pkgs/container/splice2neo with the current release v0.6.13 as tag. Can be pulled with the command:

`docker pull ghcr.io/tron-bioinformatics/splice2neo:v0.6.13`

After testing I switched the trigger to release. The pipeline should now only run when a new release was published and the tag should always be the release tag.

@johausmann
❓I edited the syntax in the Dockerfile since docker buildx in github doesn't recognize the "docker://" prefix. Will this still work for your local build? When not, we need a second Dockerfile.
❓ Is "splice2neo" as name for the image ok or would something else be more suitable?